### PR TITLE
Consistency: programmatically determine `${ENDPOINT}`

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -205,18 +205,28 @@ This command will give you a message like
 Service [grpc-calculator] revision [grpc-calculator-00001-baw] has been deployed and is serving 100 percent of traffic at https://grpc-calculator-xyspwhk3xq-uc.a.run.app
 ```
 
-We can now access the gRPC service at
-`grpc-calculator-xyspwhk3xq-uc.a.run.app:443`. Go ahead and leave the `https://`
-prefix off. Notice that this endpoint is secured with TLS even though the server
-we wrote is using a plaintext connection. Cloud Run provides a proxy that
-provides TLS for us. We'll account for that in our `grpcurl` invocation by
-leaving off the `--plaintext` flag.
+We can programmatically determine the gRPC service's endpoint:
+
+```bash
+ENDPOINT=$(\
+  gcloud run services list \
+  --project=${GCP_PROJECT} \
+  --region=${GCP_REGION} \
+  --platform=managed \
+  --format="value(status.address.url)" \
+  --filter="metadata.name=grpc-calculator") 
+ENDPOINT=${ENDPOINT#https://} && echo ${ENDPOINT}
+```
+
+Notice that this endpoint is secured with TLS even though the server we wrote uses a plaintext connection. Cloud Run provides a proxy that provides TLS for us.
+
+We'll account for this in our `grpcurl` invocation by omitting the `-plaintext` flag:
 
 ```bash
 grpcurl \
+    -proto protos/calculator.proto \
     -d '{"first_operand": 2.0, "second_operand": 3.0, "operation": "ADD"}' \
-    -proto calculator.proto \
-    grpc-calculator-xyspwhk3xq-uc.a.run.app:443 \
+    ${ENDPOINT}:443 \
     Calculator.Calculate
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -225,18 +225,28 @@ This command will give you a message like
 Service [grpc-calculator] revision [grpc-calculator-00001-baw] has been deployed and is serving 100 percent of traffic at https://grpc-calculator-xyspwhk3xq-uc.a.run.app
 ```
 
-We can now access the gRPC service at
-`grpc-calculator-xyspwhk3xq-uc.a.run.app:443`. Go ahead and leave the `https://`
-prefix off. Notice that this endpoint is secured with TLS even though the server
-we wrote is using a plaintext connection. Cloud Run provides a proxy that
-provides TLS for us. We'll account for that in our `grpcurl` invocation by
-leaving off the `--plaintext` flag.
+We can programmatically determine the gRPC service's endpoint:
+
+```bash
+ENDPOINT=$(\
+  gcloud run services list \
+  --project=${GCP_PROJECT} \
+  --region=${GCP_REGION} \
+  --platform=managed \
+  --format="value(status.address.url)" \
+  --filter="metadata.name=grpc-calculator") 
+ENDPOINT=${ENDPOINT#https://} && echo ${ENDPOINT}
+```
+
+Notice that this endpoint is secured with TLS even though the server we wrote uses a plaintext connection. Cloud Run provides a proxy that provides TLS for us.
+
+We'll account for this in our `grpcurl` invocation by omitting the `-plaintext` flag:
 
 ```bash
 grpcurl \
+    -proto protos/calculator.proto \
     -d '{"first_operand": 2.0, "second_operand": 3.0, "operation": "ADD"}' \
-    -proto calculator.proto \
-    grpc-calculator-xyspwhk3xq-uc.a.run.app:443 \
+    ${ENDPOINT}:443 \
     Calculator.Calculate
 ```
 


### PR DESCRIPTION
Make each language's `README` consistent by documenting programmatic determination of Cloud Run service's endpoint.