### PR TITLE
Fix warning in proto definition

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang@sha256:205d5cf61216a16da4431dd5796793c650236159fa04e055459940ddc4c6389c as build
+FROM golang:1.14 as build
 
 WORKDIR /srv/grpc
 

--- a/golang/client/client.go
+++ b/golang/client/client.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 
-	pb "github.com/grpc-ecosystem/grpc-cloud-run-example/golang/protos"
+	pb "github.com/grpc-ecosystem/grpc-cloud-run-example/golang/protos/calculator"
 
 	"google.golang.org/grpc"
 )

--- a/golang/client/main.go
+++ b/golang/client/main.go
@@ -8,7 +8,7 @@ import (
 	"math/rand"
 	"time"
 
-	pb "github.com/grpc-ecosystem/grpc-cloud-run-example/golang/protos"
+	pb "github.com/grpc-ecosystem/grpc-cloud-run-example/golang/protos/calculator"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/golang/protos/calculator.proto
+++ b/golang/protos/calculator.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 // Ensures that generated sources are in a Golang package called 'protos'
-option go_package = "protos";
+option go_package = "protos/calculator";
 
 enum Operation {
   ADD = 0;

--- a/golang/server/main.go
+++ b/golang/server/main.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 
-	pb "github.com/grpc-ecosystem/grpc-cloud-run-example/golang/protos"
+	pb "github.com/grpc-ecosystem/grpc-cloud-run-example/golang/protos/calculator"
 
 	"google.golang.org/grpc"
 )

--- a/golang/server/server.go
+++ b/golang/server/server.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	pb "github.com/grpc-ecosystem/grpc-cloud-run-example/golang/protos"
+	pb "github.com/grpc-ecosystem/grpc-cloud-run-example/golang/protos/calculator"
 )
 
 // Prove that Server implements pb.CalculatorServer by instantiating a Server


### PR DESCRIPTION
The proto example needs to have a path.

Following the readme, after issuing the command we have this warning.

protoc --proto_path=. --go_out=plugins=grpc:. ./protos/calculator.proto
2020/07/09 22:44:19 WARNING: Malformed 'go_package' option in "protos/calculator.proto", please specify:
        option go_package = "protos/calculator.proto;calculator_proto";
A future release of protoc-gen-go will reject this.
See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.
